### PR TITLE
Add obsidian block detection and alerts

### DIFF
--- a/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
+++ b/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
@@ -315,6 +315,9 @@ public class HypixelBedWarsMod {
                 }
             }
         }
+
+        // Check for obsidian blocks
+        if (enableItemAlerts) checkObsidian(player, state);
     }
 
     private void checkArmor(EntityPlayer player, PlayerState state) {
@@ -427,6 +430,28 @@ public class HypixelBedWarsMod {
         state.activePotions = currentPotions;
     }
     
+    private void checkObsidian(EntityPlayer player, PlayerState state) {
+        if (player.worldObj == null) return;
+
+        int radius = 5; // Define the radius to check for obsidian blocks
+        int playerX = (int) player.posX;
+        int playerY = (int) player.posY;
+        int playerZ = (int) player.posZ;
+
+        for (int x = playerX - radius; x <= playerX + radius; x++) {
+            for (int y = playerY - radius; y <= playerY + radius; y++) {
+                for (int z = playerZ - radius; z <= playerZ + radius; z++) {
+                    if (player.worldObj.getBlock(x, y, z) == Blocks.obsidian) {
+                        sendAlert(getColoredPlayerName(player) +
+                                EnumChatFormatting.DARK_PURPLE + " has placed OBSIDIAN! " +
+                                getDistanceString(player), true, "random.anvil_land");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Gets the player's name with their team color applied
      */


### PR DESCRIPTION
Add obsidian block detection and alert functionality.

* Add `checkObsidian` method to detect obsidian blocks within a 5-block radius of the player.
* Update `processPlayer` method to call `checkObsidian` if item alerts are enabled.
* Add alert message for obsidian block detection in `sendAlert` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/beenycool/bwh/pull/1?shareId=3495a37b-ade7-4da8-bf82-9c16f095f670).