### PR TITLE
Increase view distance for diamonds and emeralds

### DIFF
--- a/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
+++ b/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
@@ -75,8 +75,8 @@ public class HypixelBedWarsMod {
     private boolean enableFireballAlerts = true;
     private boolean excludeTeammates = true; // New option to exclude teammates
     private boolean enableItemESP = true; // New option for item highlighting
-    private float itemESPMaxDistance = 40.0F; // new config
-    private float itemESPFadeRange = 30.0F;   // new config
+    private float itemESPMaxDistance = 80.0F; // new config
+    private float itemESPFadeRange = 60.0F;   // new config
 
     // Sound constants for different alerts
     private static final String SOUND_ARMOR = "random.orb";


### PR DESCRIPTION
Increase the view distance for diamonds and emeralds in the item ESP configuration.

* Change `itemESPMaxDistance` value from 40.0F to 80.0F.
* Change `itemESPFadeRange` value from 30.0F to 60.0F.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/beenycool/bwh/pull/2?shareId=81253e05-27d4-4ab3-a125-2e624b1fe9df).