### PR TITLE
Fix item count display for diamonds and emeralds

### DIFF
--- a/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
+++ b/src/main/java/com/example/hypixelbedwarsmod/HypixelBedWarsMod.java
@@ -939,4 +939,11 @@ public class HypixelBedWarsMod {
         }
     }
 
-    private static class PlayerState
+    private static class PlayerState {
+        private Item lastHeldItem;
+        private boolean lastHeldDiamondSword;
+        private boolean wasHoldingFireball;
+        private int lastEmeralds;
+        private Map<Integer, Boolean> activePotions = new HashMap<>();
+    }
+}


### PR DESCRIPTION
Add a new `PlayerState` class to store player-related information.

* **PlayerState class**
  - Add `lastHeldItem` field to store the last held item.
  - Add `lastHeldDiamondSword` field to store if the player last held a diamond sword.
  - Add `wasHoldingFireball` field to store if the player was holding a fireball.
  - Add `lastEmeralds` field to store the last number of emeralds.
  - Add `activePotions` field to store active potions as a map.

